### PR TITLE
fixing reading_time bug

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -19,10 +19,10 @@
               <header>
                 <div class="entry-meta">
                   <span class="entry-date date published updated"><time datetime="{{ post.date|date }}"><a href="{{ post.url }}">{{ post.date|date("F d, Y") }}</a></time></span><span class="author vcard"><span class="fn"><a href="{{ base_url_relative }}/about" title="About {{ site.owner.name }}">{{ site.owner.name }}</a></span></span>{# {% if site.disqus_shortname and post.comments %}&nbsp; &bull; &nbsp;<span class="entry-comments"><a href="{{ base_url_relative }}{{ post.url }}#disqus_thread">Comment</a></span>{% endif %} #}
-                  {% if config.plugins.readingtime.enabled %}
+                  {% if config.plugins.reading_time.enabled %}
                   <span class="entry-reading-time pull-right">
                     <i class="fa fa-clock-o"></i>
-                    Reading time ~{{ post.content|readingtime({'round':'minutes'}) }}
+                    Reading time ~{{ post.content|reading_time({'round':'minutes'}) }}
                   </span><!-- /.entry-reading-time -->
                   {% endif %}
                 </div><!-- /.entry-meta -->

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -39,10 +39,10 @@
                 {% if page.header.date %}
                 <h2>{{ page.date | date("F d, Y") }}</h2>
                 {% endif %}
-                {% if config.plugins.readingtime.enabled %}
+                {% if config.plugins.reading_time.enabled %}
                   <p class="entry-reading-time">
                     <i class="fa fa-clock-o"></i>
-                    Reading time ~{{ page.content|readingtime({'round':'minutes'}) }}
+                    Reading time ~{{ page.content|reading_time({'round':'minutes'}) }}
                   </p><!-- /.entry-reading-time -->
                 {% endif %}
               </div><!-- /.header-title-wrap -->


### PR DESCRIPTION
The reading time plugin does not work as it uses "reading_time" (with underscore), the theme however is using "readingtime" (no underscore).