### PR TITLE
Added support for continue to read button

### DIFF
--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -33,8 +33,15 @@
                 {% endif %}
               </header>
               <div class="entry-content">
-                {{ post.content }}
-              </div><!-- /.entry-content -->
+                {% if post.header.continue_link %}
+                  {{ post.summary }}
+                  <br>
+                  <a href="{{ post.url }}" title="{{ post.title }}" class="btn btn-primary">Continue Reading</a>
+                {% else %}
+                  {{ post.content }}
+                {% endif %}
+              </div>
+              <!-- /.entry-content -->
             </article><!-- /.hentry -->
         {% endfor %}
 


### PR DESCRIPTION
Added a check for the frontmatter var 'continue_link' to optionally only display a post summary and present a button to continue reading the entire post.

I've structured the if statement so existing blog entries without any continue_link flag will automatically be presented in their entirety.