### PR TITLE
display summary instead of content on overview

### DIFF
--- a/hpstr.yaml
+++ b/hpstr.yaml
@@ -2,3 +2,5 @@ enabled: true
 color: blue
 dropdown:
   enabled: false
+pages: 
+  display: content # content, summary, custom

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -1,7 +1,7 @@
 {% embed 'partials/base.html.twig' %}
 
-	{% set collection = page.collection() %}
-	{% set base_url = page.url %}
+    {% set collection = page.collection() %}
+    {% set base_url = page.url %}
     {% set feed_url = base_url %}
 
     {% if base_url == '/' %}
@@ -12,7 +12,7 @@
         {% set feed_url = base_url~'/'~page.slug %}
     {% endif  %}
 
-	{% block content %}
+    {% block content %}
 
         {% for post in collection %}
             <article class="hentry">
@@ -33,7 +33,15 @@
                 {% endif %}
               </header>
               <div class="entry-content">
-                {{ post.summary }}
+                {% if grav.theme.config.pages.display == 'content' %}
+                    {{ post.content }}
+                {% elseif grav.theme.config.pages.display == 'summary' %}
+                    {{ post.summary }}
+                {% elseif grav.theme.config.pages.display == 'custom' %}
+                    {% include 'partials/pages-displaytext.html.twig' %}
+                {% else %}
+                    {{ post.summary }}
+              {% endif %}
               </div><!-- /.entry-content -->
             </article><!-- /.hentry -->
         {% endfor %}
@@ -42,7 +50,7 @@
         {% include 'partials/pagination.html.twig' with {'pagination':collection.params.pagination} %}
         {% endif %}
 
-	{% endblock %}
+    {% endblock %}
 
 {% endembed %}
 

--- a/templates/page.html.twig
+++ b/templates/page.html.twig
@@ -33,7 +33,7 @@
                 {% endif %}
               </header>
               <div class="entry-content">
-                {{ post.content }}
+                {{ post.summary }}
               </div><!-- /.entry-content -->
             </article><!-- /.hentry -->
         {% endfor %}

--- a/templates/partials/pages-displaytext.html.twig
+++ b/templates/partials/pages-displaytext.html.twig
@@ -1,0 +1,7 @@
+{% if post.summary == post.content %}
+    {{ post.content }}
+{% else %}
+    {{ post.summary }}
+    <br>
+    <a href="{{ post.url }}" title="{{ post.title }}" class="btn btn-primary">Continue reading</a>
+{% endif %}


### PR DESCRIPTION
the article index pages currently show the full content of the article instead of the summary; this PR replaces `{{ post.content }}` with `{{ post.summary }}` which can be controlled by the [summary configuration setting](https://learn.getgrav.org/content/headers#summary)