### PR TITLE
Fix: auto-escaping in entry-image.

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -67,7 +67,7 @@
       {% if page.header.image.credit %}<div class="image-credit">Image source: <a href="{{ page.header.image.creditlink }}">{{ page.header.image.credit }}</a></div><!-- /.image-credit -->{% endif %}
       {% if page.header.image.feature %}
         <div class="entry-image">
-          {{ page.media[page.header.image.feature].html }}
+          {{ page.media[page.header.image.feature].html | raw }}
         </div><!-- /.entry-image -->
       {% endif %}
       <div class="header-title">


### PR DESCRIPTION
This patch applies the guidelines for upgrading to 1.6.

Indeed, after testing this template on a fresh install of Grav, I couldn't visually see the "entry-image" without converting to raw. 

As explained through the migration guide https://learn.getgrav.org/17/advanced/grav-development/grav-16-upgrade-guide#auto-escaping 

"The transition to use auto-escaping will not be easy. During the transition, all the template files should either contain both `|e` and `|raw` filters on every variable to make sure that the template file is safe to be used in both modes, or you can surround all the template code with `{% autoescape %}` Twig tags."
